### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dice Roller
 
 This is a simple dice roller written as an exercise to learn Crystal.
-It uses [https://github.com/Fusion/libui.cr](libui) for the GUI.
+It uses [libui.cr](https://github.com/Fusion/libui.cr) for the GUI.
 
 ## Installation
 


### PR DESCRIPTION
The text and URL were the wrong way around, resulting in a broken link.